### PR TITLE
Optionally build ITK 5.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,12 @@ set(TomvizSuper_DEFAULT_ARGS
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 list(APPEND TomvizSuper_DEFAULT_ARGS "-DQt5_DIR:PATH=${Qt5_DIR}")
 
+# Optionally build ITK, it is probably simpler to pip install it if needed.
+option(BUILD_ITK "Built ITK for ITK-based operators" OFF)
+if(BUILD_ITK)
+  include(external_itk)
+endif()
+
+# Now build ParaView followed by Tomviz.
 include(external_paraview)
 include(external_tomviz)

--- a/cmake/external_itk.cmake
+++ b/cmake/external_itk.cmake
@@ -1,0 +1,31 @@
+set(_url "https://github.com/InsightSoftwareConsortium/ITK/releases/download/v5.0.1/InsightToolkit-5.0.1.tar.gz")
+set(_hash "f36613ff72c513ded3d32504f71308a94fe75555cf9fd22b77485d1375601f6e1f1539cc5ac82a9e1e229bcf514a88ccb55122a7dfc74a6ae1b6604aa70bd814")
+set(_build "${CMAKE_CURRENT_BINARY_DIR}/itk")
+
+unset(_deps)
+
+ExternalProject_Add(itk
+  URL ${_url}
+  URL_HASH SHA512=${_hash}
+  BINARY_DIR ${_build}
+  INSTALL_COMMAND ""
+  CMAKE_CACHE_ARGS
+    ${TomvizSuper_DEFAULT_ARGS}
+    -DITK_LEGACY_REMOVE:BOOL=ON
+    -DITK_LEGACY_SILENT:BOOL=ON
+    -DModule_ITKBridgeNumPy:BOOL=ON
+    -DBUILD_TESTING:BOOL=OFF
+    -DITK_WRAP_unsigned_short:BOOL=ON
+    -DITK_WRAP_rgb_unsigned_char:BOOL=OFF
+    -DITK_WRAP_rgba_unsigned_char:BOOL=OFF
+    -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF
+    -DITKGroup_Core:BOOL=ON
+    -DITKGroup_Filtering:BOOL=ON
+    -DITKGroup_Segmentation:BOOL=ON
+    -DITKGroup_Nonunit:BOOL=ON
+    -DPython_ADDITIONAL_VERSIONS:STRING=3
+    -DITK_WRAP_PYTHON:BOOL=ON
+    -DBUILD_EXAMPLES:BOOL=OFF
+  DEPENDS
+    ${_deps}
+    )


### PR DESCRIPTION
It is probably simpler/faster to pip install ITK for development, but
added an option (OFF by default) to build. It would need some Python
environment magic to be seen by the operators.